### PR TITLE
Add rust support for vim

### DIFF
--- a/ctags
+++ b/ctags
@@ -18,6 +18,15 @@
 --regex-Elixir=/^[ \t]*Record\.defrecord[ \t]+:([a-zA-Z0-9_]+)/\1/r,records,records/
 --regex-Elixir=/^[ \t]*test[ \t]+\"([a-z_][a-zA-Z0-9_?! ]*)\"*/\1/t,tests,tests/
 
+--langdef=Rust
+--langmap=Rust:.rs
+--regex-Rust=/fn +([a-zA-Z0-9_]+) *[(<{]/\1/f,functions,function definitions/
+--regex-Rust=/(type|enum|struct|trait)[ \t]+([a-zA-Z0-9_]+) *[<{(;]/\2/T,types,type definitions/
+--regex-Rust=/mod[ \t]+([a-zA-Z0-9_]+) *[<{(;]/\1/M,modules,module definitions/
+--regex-Rust=/(static|const) +([a-zA-Z0-9_]+) *[:=]/\2/c,consts,static constants/
+--regex-Rust=/macro_rules! +([a-zA-Z0-9_]+) *{/\1/d,macros,macro definitions/
+--regex-Rust=/impl([ \t\n]*<[^>]*>)?[ \t]+(([a-zA-Z0-9_:]+)[ \t]*(<[^>]*>)?[ \t]+(for)[ \t]+)?([a-zA-Z0-9_]+)/\6/i,impls,trait implementations/
+
 --exclude=*.min.js
 
 --exclude=.git

--- a/hooks/vim-plugins
+++ b/hooks/vim-plugins
@@ -5,6 +5,7 @@ bundles="
   altercation/vim-colors-solarized
   calleerlandsson/pick.vim
   pbrisbin/vim-mkdir
+  rust-lang/rust.vim
   teoljungberg/vim-grep-motion
   teoljungberg/vim-visual-star-search
   tommcdo/vim-exchange

--- a/hooks/vim-plugins
+++ b/hooks/vim-plugins
@@ -5,6 +5,7 @@ bundles="
   altercation/vim-colors-solarized
   calleerlandsson/pick.vim
   pbrisbin/vim-mkdir
+  racer-rust/vim-racer
   rust-lang/rust.vim
   teoljungberg/vim-grep-motion
   teoljungberg/vim-visual-star-search

--- a/vim/ftplugin/rust.vim
+++ b/vim/ftplugin/rust.vim
@@ -3,3 +3,5 @@ let g:ftplugin_rust_source_path =
 let g:racer_cmd = "$HOME/.cargo/bin/racer"
 
 setlocal iskeyword+=!
+
+nmap <buffer> K <Plug>(rust-doc)

--- a/vim/ftplugin/rust.vim
+++ b/vim/ftplugin/rust.vim
@@ -5,3 +5,4 @@ let g:racer_cmd = "$HOME/.cargo/bin/racer"
 setlocal iskeyword+=!
 
 nmap <buffer> K <Plug>(rust-doc)
+nmap <buffer> gd <Plug>(rust-def)

--- a/vim/ftplugin/rust.vim
+++ b/vim/ftplugin/rust.vim
@@ -1,0 +1,1 @@
+setlocal iskeyword+=!

--- a/vim/ftplugin/rust.vim
+++ b/vim/ftplugin/rust.vim
@@ -1,1 +1,5 @@
+let g:ftplugin_rust_source_path =
+      \ "$(rustc --print sysroot)/lib/rustlib/src/rust/src"
+let g:racer_cmd = "$HOME/.cargo/bin/racer"
+
 setlocal iskeyword+=!


### PR DESCRIPTION
- Add ctags(1) support for rust.
- Add `rust.vim`,
- Consider `!` to be a keyword
- Setup vim-racer for rust(1).
- Add `K` to open the rust documentation.
- Jump to definition with `gd`.

Closes #7