### PR TITLE
Update ruby-install.nix

### DIFF
--- a/nixpkgs/ruby-install.nix
+++ b/nixpkgs/ruby-install.nix
@@ -1,18 +1,8 @@
-{ pkgs ? import <nixpkgs> { }
-, buildEnv ? pkgs.buildEnv
-, gcc ? pkgs.gcc
-, gdbm ? pkgs.gdbm
-, gnugrep ? pkgs.gnugrep
-, gnumake ? pkgs.gnumake
-, libyaml ? pkgs.libyaml
-, makeWrapper ? pkgs.makeWrapper
-, ncurses ? pkgs.ncurses
-, openssl ? pkgs.openssl
-, pkg-config ? pkgs.pkg-config
-, readline ? pkgs.readline
-, stdenv ? pkgs.stdenv
-, zlib ? pkgs.zlib
-}:
+{ pkgs ? import <nixpkgs> { }, buildEnv ? pkgs.buildEnv, gcc ? pkgs.gcc
+, gdbm ? pkgs.gdbm, gnugrep ? pkgs.gnugrep, gnumake ? pkgs.gnumake
+, libyaml ? pkgs.libyaml, makeWrapper ? pkgs.makeWrapper, ncurses ? pkgs.ncurses
+, openssl ? pkgs.openssl, pkg-config ? pkgs.pkg-config, readline ? pkgs.readline
+, stdenv ? pkgs.stdenv, zlib ? pkgs.zlib }:
 
 let
   paths = [
@@ -27,14 +17,14 @@ let
     pkg-config
     readline
     zlib
+    zlib.dev
   ];
   env = buildEnv {
     name = "ruby-install-env";
     paths = paths;
     extraOutputsToInstall = [ "bin" "include" "lib" ];
   };
-in
-stdenv.mkDerivation {
+in stdenv.mkDerivation {
   pname = "ruby-install";
   version = "0.8.2";
 


### PR DESCRIPTION
When trying to install Ruby 3.1.2 with `ruby-install 3.1.2` I got the following error.

```sh
addr2line.c:100:12: fatal error: zlib.h: No such file or directory
  100 | #  include <zlib.h>
      |            ^~~~~~~~
```

Updating the build input from `zlib` to `zlib.dev` and running `ruby-install` again successfully builds on my machine.